### PR TITLE
Improve Acceptance Test and Ember Page Object compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ import WidgetItem from 'wherever';
 getComponent.instanceByConstructor(WidgetItem);
 ```
 
+##### Get just the query selector
+```js
+const WIDGET_SELECTOR = getComponent.selectorByName('widget-item');
+const SPECIAL_WIDGET_SELECTOR = getComponent.selectorByName('specialWidget');
+```
+
 ##### Super Deluxe Debugging
 The debugger provides a list of components by name and testAttr as well as cut-and-paste-ready mocha assertions for testing visibility. Use it as a starting point in your tests.
 ```js

--- a/addon/index.js
+++ b/addon/index.js
@@ -17,7 +17,7 @@ const DOCUMENTATION_URL = 'https://github.com/AltSchool/ember-get-component';
  * @return {jQuery} a jQuery result set
  */
 const elementsByName = function(name) {
-  return getContext().$(_selectorByName(name));
+  return $(selectorByName(name));
 };
 
 /**
@@ -29,7 +29,7 @@ const elementsByName = function(name) {
  * @return {jQuery} a jQuery result set
  */
 const elementsByTestAttr = function(testAttr) {
-  return getContext().$(_selectorByTestAttr(testAttr));
+  return $(selectorByTestAttr(testAttr));
 };
 
 /**
@@ -61,7 +61,7 @@ const instanceByTestAttr = function(testAttr) {
  * @return {Component}
  */
 const instanceByConstructor = function(constructor) {
-  const parent = findComponentBySelector(getContext().$());
+  const parent = findComponentBySelector($());
   return findComponentByConstructor(constructor, parent);
 };
 
@@ -76,9 +76,8 @@ const instanceByConstructor = function(constructor) {
  *
  */
 const debug = function() {
-  const context = getContext();
-  const $testAttrs = context.$('[data-test-attr]');
-  const $components = context.$('[data-test-component-name]');
+  const $testAttrs = $('[data-test-attr]');
+  const $components = $('[data-test-component-name]');
   if ($components.length) {
     _logElements({
       '$items': $components,
@@ -147,12 +146,18 @@ function _logExampleCode({ $items, headerText, targetAttr, getElementMethodName 
   console.log(code);
 }
 
-function _selectorByName(name) {
+function selectorByName(name) {
   return `[data-test-component-name="${name}"]`;
 }
 
-function _selectorByTestAttr(testAttr) {
+function selectorByTestAttr(testAttr) {
   return `[data-test-attr="${testAttr}"]`;
+}
+
+function $() {
+  const context = getContext();
+  const jq = context && context.$ || Ember.$;
+  return jq(...arguments);
 }
 
 /**
@@ -190,5 +195,7 @@ export default {
   instanceByName,
   instanceByTestAttr,
   instanceByConstructor,
+  selectorByName,
+  selectorByTestAttr,
   debug
 };

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,55 +2,30 @@
 module.exports = {
   scenarios: [
     {
-      name: 'default',
-      bower: {
-        dependencies: { }
-      }
+      name: 'Ember 1.13',
+      bower: { dependencies: { 'ember': '1.13.0'  } }
     },
+
     {
-      name: 'ember-1-13',
-      bower: {
-        dependencies: {
-          'ember': '~1.13.0'
-        },
-        resolutions: {
-          'ember': '~1.13.0'
-        }
-      }
+      name: 'Ember 2.4.5',
+      bower: { dependencies: {  'ember': '2.4.5'  } }
     },
+
     {
-      name: 'ember-release',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#release'
-        },
-        resolutions: {
-          'ember': 'release'
-        }
-      }
-    },
-    {
-      name: 'ember-beta',
+      name: 'Ember canary',
       allowedToFail: true,
       bower: {
-        dependencies: {
-          'ember': 'components/ember#beta'
-        },
-        resolutions: {
-          'ember': 'beta'
-        }
+        dependencies: { 'ember': 'components/ember#canary' },
+        resolutions: { 'ember': 'canary' }
       }
     },
+
     {
-      name: 'ember-canary',
+      name: 'Ember beta',
       allowedToFail: true,
       bower: {
-        dependencies: {
-          'ember': 'components/ember#canary'
-        },
-        resolutions: {
-          'ember': 'canary'
-        }
+        dependencies: { 'ember': 'components/ember#beta' },
+        resolutions: { 'ember': 'beta' }
       }
     }
   ]

--- a/ember-try.js
+++ b/ember-try.js
@@ -1,4 +1,0 @@
-/*jshint node:true*/
-module.exports = {
-  useVersionCompatibility: true
-};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-get-component",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Simple way to find Ember Components within tests.",
   "directories": {
     "doc": "doc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-get-component",
-  "version": "0.2.0",
+  "version": "0.2.0-beta-1",
   "description": "Simple way to find Ember Components within tests.",
   "directories": {
     "doc": "doc",
@@ -43,7 +43,7 @@
     "ember-resolver": "^2.0.3",
     "ember-sinon": "0.5.1",
     "ember-test-helpers": "0.5.27",
-    "ember-try": "^0.2.2",
+    "ember-try": "^0.2.5",
     "loader.js": "^4.0.0"
   },
   "keywords": [


### PR DESCRIPTION
### Acceptance Test Compatibility 
**Problem:** getComponent selectors were failing in Acceptance tests. This is because it expected `context.$` to exist, which it does for Component Integration tests but not for Acceptance tests.

**Solution:** We now default to `context.$` but fallback to `Ember.$`.

### Ember Page Object compatibility
**Problem:** Some libraries, like [Ember Page Objects](http://ember-cli-page-object.js.org/docs/v1.6.x/), expect element queries strings. We did not provide a way to get those. 

**Solution:** Now we export the previously private functions `selectorByName` and `selectorByTestAttr`.



