### PR TITLE
Ember 2.10 Compatibility

### DIFF
--- a/addon/find-component-by-constructor.js
+++ b/addon/find-component-by-constructor.js
@@ -4,37 +4,13 @@ import {
   getContext
 } from 'ember-test-helpers';
 
-/**
- * Finds the first instance of a particular component, given some constructor
- * and parent.
- *
- * Note that this is technically a depth-first search, but it will search each
- * level before proceeding to the next.  In other words, given:
- *
- * a
- *  b1
- *   c1
- *    d1
- *    d2
- *   c2
- *    d3
- *    d4
- *  b2
- *   c3
- *   c4
- *  b3
- *   c5
- *
- * This will search in the following order:
- *
- * b1, b2, b3, c1, c2, d1, d2, d3, d4, c3, c4, c5
- */
 export default function findComponentByConstructor(constructor, parent) {
+  //
   const registry = getContext().container.lookup('-view-registry:main');
 
-  for (let [k,v] of Object.entries(registry)) {
-    if (v instanceof constructor) {
-      return v;
+  for (let [viewId, viewInstance] of Object.entries(registry)) {
+    if (viewInstance instanceof constructor) {
+      return viewInstance;
     }
   }
 

--- a/addon/find-component-by-constructor.js
+++ b/addon/find-component-by-constructor.js
@@ -30,9 +30,12 @@ import {
  * b1, b2, b3, c1, c2, d1, d2, d3, d4, c3, c4, c5
  */
 export default function findComponentByConstructor(constructor, parent) {
-  const children = parent.childViews || [];
-  return children.find((child) => child instanceof constructor) ||
-    children.reduce((instance, child) => {
-      return instance || findComponentByConstructor(constructor, child);
-    }, undefined);
+  const registry = getContext().container.lookup('-view-registry:main');
+
+  for (let [k,v] of Object.entries(registry)) {
+    if (v instanceof constructor) {
+      return v;
+    }
+  }
+
 }

--- a/addon/index.js
+++ b/addon/index.js
@@ -201,5 +201,7 @@ export default {
   instanceByConstructor,
   selectorByName,
   selectorByTestAttr,
+  findComponentBySelector,
+  findComponentByConstructor,
   debug
 };


### PR DESCRIPTION
Pre 2.10, `ember-get-component` relied on the existence of the `childViews` property on a given component. The addon then traversed that parent component child views to find the component instance we're probably interested in testing.

In 2.10, `childViews` is not reliable at all and was advised by rwjblue that it should not be used. We ended up using the view registry which is also private and will likely not exist in the future, but this is at least not a regression and keeps our tests running.

Context:
https://github.com/emberjs/ember.js/issues/11244