### PR TITLE
testAttr should not override pre-existing data-test-attr

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -173,13 +173,32 @@ const init = function() {
       const name = this.constructor.toString();
 
       // Do nothing if it's a tagless component
+
       if (this.get('tagName') === '') {
         return;
       }
 
       // if it's not tagless, add the attrs to existing ones
-      const attrBindings = this.getWithDefault('attributeBindings', []);
-      this.set('attributeBindings', [...attrBindings, 'data-test-component-name', 'testAttr:data-test-attr']);
+
+      const attrBindings = [
+        ...this.getWithDefault('attributeBindings', []),
+        'data-test-component-name'
+      ];
+
+      const getComponentDataTestAttrBinding = 'testAttr:data-test-attr';
+      const conflictingDataTestAttrBinding = attrBindings.find((attr) => {
+        return /(^|:)data-test-attr$/.test(attr) && attr !== getComponentDataTestAttrBinding;
+      });
+
+      if (!conflictingDataTestAttrBinding) {
+        attrBindings.push(getComponentDataTestAttrBinding);
+      } else if (this.get('testAttr')) {
+        throw new Ember.Error(
+          'cannot use `testAttr` if the component already has a `data-test-attr` binding'
+        );
+      }
+
+      this.set('attributeBindings', attrBindings);
       this.set('data-test-component-name', this.getWithDefault('data-test-component-name', null));
 
       // TODO: For now, this check is required to skip over generic components

--- a/tests/integration/get-component-test.js
+++ b/tests/integration/get-component-test.js
@@ -21,6 +21,9 @@ import register from '../helpers/register';
 import getComponent from 'ember-get-component';
 
 const FakeComponent = Component.extend({});
+const FakeDataTestAttrComponent = Component.extend({
+  attributeBindings: ['data-test-attr']
+});
 
 describeComponent(
   'get-component',
@@ -32,12 +35,31 @@ describeComponent(
 
     beforeEach(function() {
       register('component:fake-component', FakeComponent);
+      register('component:fake-component-with-data-test-attr', FakeDataTestAttrComponent);
       getComponent.init();
     });
 
     it('renders', function() {
       this.render(hbs`{{fake-component class="fake"}}`);
       expect(this.$('.fake')).to.have.length(1);
+    });
+
+    it('throws an error if testAttr overlaps with existing data-test-attr binding', function() {
+      const fn = () => {
+        this.render(hbs`
+          {{fake-component-with-data-test-attr testAttr="duck"}}
+        `);
+      }
+
+      expect(fn).to.throw(/cannot use `testAttr`/);
+    });
+
+    it('respects preexisting `data-test-attr` binding', function() {
+      this.render(hbs`
+        {{fake-component-with-data-test-attr data-test-attr="foo"}}
+      `);
+
+      expect(this.$('[data-test-attr="foo"]')).to.have.length(1);
     });
 
     describe('elementsByName', function() {
@@ -157,7 +179,6 @@ describeComponent(
         expect(logs).to.contain('expect(getComponent.elementsByTestAttr(\'fooTestAttr\')).to.have.length(2);');
       });
     });
-
   }
 );
 

--- a/tests/integration/get-component-test.js
+++ b/tests/integration/get-component-test.js
@@ -20,11 +20,6 @@ import hbs from 'htmlbars-inline-precompile';
 import register from '../helpers/register';
 import getComponent from 'ember-get-component';
 
-const FakeComponent = Component.extend({});
-const FakeDataTestAttrComponent = Component.extend({
-  attributeBindings: ['data-test-attr']
-});
-
 describeComponent(
   'get-component',
   'Integration: GetComponentTestHelper',
@@ -32,10 +27,32 @@ describeComponent(
     integration: true
   },
   function() {
+    const FakeComponent = Component.extend({
+      // attribute binding that does not clash with `testAttr`
+      attributeBindings: ['my-data-test-attribute']
+    });
+    const FakeDataTestAttrComponent = Component.extend({
+      // attribute binding that clashes with `testAttr`
+      attributeBindings: ['data-test-attr']
+    });
+    const FakeNamedTestAttrComponent = Component.extend({
+      // attribute binding that clashes with `testAttr`
+      attributeBindings: ['attr:data-test-attr']
+    });
 
     beforeEach(function() {
-      register('component:fake-component', FakeComponent);
-      register('component:fake-component-with-data-test-attr', FakeDataTestAttrComponent);
+      register(
+        'component:fake-component',
+        FakeComponent
+      );
+      register(
+        'component:fake-component-with-data-test-attr-binding',
+        FakeDataTestAttrComponent
+      );
+      register(
+        'component:fake-component-with-named-data-test-attr-binding',
+        FakeNamedTestAttrComponent
+      );
       getComponent.init();
     });
 
@@ -44,25 +61,51 @@ describeComponent(
       expect(this.$('.fake')).to.have.length(1);
     });
 
-    it('throws an error if testAttr overlaps with existing data-test-attr binding', function() {
-      const fn = () => {
+    describe('#init', function() {
+      it('sets `data-test-attr` if `testAttr` is passed into the component', function() {
+        this.render(hbs`{{fake-component testAttr="foo"}}`);
+
+        expect(this.$('[data-test-attr="foo"]')).to.have.length(1);
+      });
+
+      it('throws an error if `testAttr` overlaps with existing `data-test-attr` binding', function() {
+        const fn = () => {
+          this.render(hbs`
+            {{fake-component-with-data-test-attr-binding testAttr="duck"}}
+          `);
+        }
+
+        expect(fn).to.throw(/cannot use `testAttr`/);
+      });
+
+      it('throws an error if `testAttr` overlaps with existing `data-test-attr` bound to named property', function() {
+        const fn = () => {
+          this.render(hbs`
+            {{fake-component-with-named-data-test-attr-binding testAttr="duck"}}
+          `);
+        }
+
+        expect(fn).to.throw(/cannot use `testAttr`/);
+      });
+
+      it('respects preexisting `data-test-attr` binding', function() {
         this.render(hbs`
-          {{fake-component-with-data-test-attr testAttr="duck"}}
+          {{fake-component-with-data-test-attr-binding data-test-attr="foo"}}
         `);
-      }
 
-      expect(fn).to.throw(/cannot use `testAttr`/);
+        expect(this.$('[data-test-attr="foo"]')).to.have.length(1);
+      });
+
+      it('respects preexisting `data-test-attr` bound to named property', function() {
+        this.render(hbs`
+          {{fake-component-with-named-data-test-attr-binding attr="foo"}}
+        `);
+
+        expect(this.$('[data-test-attr="foo"]')).to.have.length(1);
+      });
     });
 
-    it('respects preexisting `data-test-attr` binding', function() {
-      this.render(hbs`
-        {{fake-component-with-data-test-attr data-test-attr="foo"}}
-      `);
-
-      expect(this.$('[data-test-attr="foo"]')).to.have.length(1);
-    });
-
-    describe('elementsByName', function() {
+    describe('#elementsByName', function() {
       it('returns component elements by name', function() {
         this.render(hbs`
           {{fake-component}}
@@ -73,7 +116,7 @@ describeComponent(
       });
     });
 
-    describe('elementsByTestAttr', function() {
+    describe('#elementsByTestAttr', function() {
       it('returns component elements by testAttr', function() {
         this.render(hbs`
           {{fake-component testAttr="duck"}}
@@ -85,7 +128,7 @@ describeComponent(
       });
     });
 
-    describe('instanceByName', function() {
+    describe('#instanceByName', function() {
       it('returns a component instance by name', function() {
         this.render(hbs`
           {{fake-component}}
@@ -95,7 +138,7 @@ describeComponent(
       });
     });
 
-    describe('instanceByTestAttr', function() {
+    describe('#instanceByTestAttr', function() {
       it('returns a component instance by testAttr', function() {
         this.render(hbs`
           {{fake-component testAttr="beans"}}
@@ -105,7 +148,7 @@ describeComponent(
       });
     });
 
-    describe('instanceByConstructor', function() {
+    describe('#instanceByConstructor', function() {
       it('returns a component instance by constructor', function() {
         this.render(hbs`
           {{fake-component}}
@@ -123,7 +166,7 @@ describeComponent(
       });
     });
 
-    describe('debug', function() {
+    describe('#debug', function() {
       let logs = '';
       const collectLog = log => logs += `${log}\n`;
       beforeEach(function() {


### PR DESCRIPTION
### Purpose
Ensure that `data-test-attr` bindings that already exist on a component are not overridden by `ember-get-component` when `Ember.Component` is reopened by `getComponent.init`.